### PR TITLE
Fix issue with Builder.set_error (undefined method `error=')

### DIFF
--- a/lib/collection-json/builder.rb
+++ b/lib/collection-json/builder.rb
@@ -5,7 +5,7 @@ module CollectionJSON
     end
 
     def set_error(params = {})
-      @collection.error = params
+      @collection.error params
     end
 
     def add_link(href, rel, params = {})


### PR DESCRIPTION
Tiny commit for the set_error method which didn't work.

Reproduce the error with:

``` ruby
collection = CollectionJSON.generate_for(api_auth_url) do |builder|
    builder.set_error(title: 'authentication_failed', message: 'Invalid username/password')
end
```

``` ruby
NoMethodError (undefined method `error=' for #<CollectionJSON::Collection:0xbcfc8d4>):
```
