### PR TITLE
don't send keys unless I changed them

### DIFF
--- a/lib/collection-json/attributes/template.rb
+++ b/lib/collection-json/attributes/template.rb
@@ -11,9 +11,13 @@ module CollectionJSON
       {'template' => Hash.new}.tap do |hash|
         hash['template']['data'] = data.inject([]) do |array,data|
           result = {'name' => data.name, 'value' => data.value}
-          result['value'] = params[data.name] unless params[data.name].nil?
-          result['value'] = params[data.name.to_sym] unless params[data.name.to_sym].nil?
-          result['value'].nil? ? array : array << result
+          result['value'] = params[data.name] if params.has_key?(data.name)
+          result['value'] = params[data.name.to_sym] if params.has_key?(data.name.to_sym)
+          if params.has_key?(data.name) || params.has_key?(data.name.to_sym)
+            array << result
+          else
+            array
+          end
         end
       end
     end


### PR DESCRIPTION
Thanks for the awesome gem.

I did have one "problem". In our API, we don't always expect people to send the full template with the values that just exist in the value field of the template. Sometimes we might want to not send that data at all and let the server just default by not including that data attribute at all. We also have data attributes that need to have JSON null values, which you couldn't do since it stripped out any nil fields. 

What do you think about this? Feel free to disagree about our api choices too, although my reading of the spec didn't make it any clearer.
