### PR TITLE
Fix test deprecations in RSpec

### DIFF
--- a/spec/collection-json/attributes/collection_spec.rb
+++ b/spec/collection-json/attributes/collection_spec.rb
@@ -10,6 +10,6 @@ describe CollectionJSON::Collection do
           data: [{name: 'full-name', value: 'phil'}]
         }]
       })
-    collection.to_json.class.should eq(String)
+    expect(collection.to_json.class).to eq(String)
   end
 end

--- a/spec/collection-json/attributes/data_spec.rb
+++ b/spec/collection-json/attributes/data_spec.rb
@@ -3,6 +3,6 @@ require 'collection-json/attributes/data'
 
 describe CollectionJSON::Data do
   it 'displays value "false"' do
-    CollectionJSON::Data.from_hash(value: false).to_json.should == "{\"value\":false}"
+    expect(CollectionJSON::Data.from_hash(value: false).to_json).to eq "{\"value\":false}"
   end
 end

--- a/spec/collection-json/attributes/item_spec.rb
+++ b/spec/collection-json/attributes/item_spec.rb
@@ -8,6 +8,6 @@ describe CollectionJSON::Item do
       links: [{href: 'http://www.example.com/place'}],
       data: [{name: 'full-name', value: 'phil'}]
       })
-    item.to_json.class.should eq(String)
+    expect(item.to_json.class).to eq(String)
   end
 end

--- a/spec/collection-json/attributes/template_spec.rb
+++ b/spec/collection-json/attributes/template_spec.rb
@@ -26,8 +26,8 @@ describe CollectionJSON::Template do
       })
       json = result.to_json
       hash = JSON.parse(json)
-      hash['template']['data'].length.should eq(2)
-      hash['template']['data'].first.keys.length.should eq(2)
+      expect(hash['template']['data'].length).to eq(2)
+      expect(hash['template']['data'].first.keys.length).to eq(2)
     end
   end
 end

--- a/spec/collection-json/transformers/uri_spec.rb
+++ b/spec/collection-json/transformers/uri_spec.rb
@@ -10,7 +10,7 @@ describe CollectionJSON::URI do
     it 'returns full uri' do
       ENV['COLLECTION_JSON_HOST'] = EXAMPLE_HOST
       uri = CollectionJSON::URI.call(@href)
-      uri.should eq("http://localhost/friends")
+      expect(uri).to eq("http://localhost/friends")
     end
   end
 
@@ -18,7 +18,7 @@ describe CollectionJSON::URI do
     it 'returns partial uri' do
       ENV['COLLECTION_JSON_HOST'] = nil
       uri = CollectionJSON::URI.call(@href)
-      uri.should eq("/friends")
+      expect(uri).to eq("/friends")
     end
   end
 end

--- a/spec/collection-json_spec.rb
+++ b/spec/collection-json_spec.rb
@@ -45,20 +45,20 @@ describe CollectionJSON do
         end
       end
 
-      response.href.should eq('/friends/')
-      response.links.first.href.should eq("/friends/rss")
-      response.link('feed').href.should eq("/friends/rss")
-      response.items.length.should eq(3)
-      response.items.first.data.length.should eq(2)
-      response.items.first.datum('full-name').value.should eq("J. Doe")
-      response.items.first.links.length.should eq(2)
-      response.items.first.href.class.should eq(String)
-      response.template.data.length.should eq(4)
-      response.queries.length.should eq(1)
-      response.queries.first.href.should eq("/friends/search")
-      response.queries.first.data.length.should eq(1)
-      response.queries.first.data.first.name.should eq('search')
-      response.query('search').prompt.should eq('Search')
+      expect(response.href).to eq('/friends/')
+      expect(response.links.first.href).to eq("/friends/rss")
+      expect(response.link('feed').href).to eq("/friends/rss")
+      expect(response.items.length).to eq(3)
+      expect(response.items.first.data.length).to eq(2)
+      expect(response.items.first.datum('full-name').value).to eq("J. Doe")
+      expect(response.items.first.links.length).to eq(2)
+      expect(response.items.first.href.class).to eq(String)
+      expect(response.template.data.length).to eq(4)
+      expect(response.queries.length).to eq(1)
+      expect(response.queries.first.href).to eq("/friends/search")
+      expect(response.queries.first.data.length).to eq(1)
+      expect(response.queries.first.data.first.name).to eq('search')
+      expect(response.query('search').prompt).to eq('Search')
     end
   end
 
@@ -82,24 +82,24 @@ describe CollectionJSON do
     end
 
     it 'should parse JSON into a Collection' do
-      @collection.class.should eq(CollectionJSON::Collection)
+      expect(@collection.class).to eq(CollectionJSON::Collection)
     end
 
     it 'should have correct href' do
-      @collection.href.should eq("http://www.example.org/friends")
+      expect(@collection.href).to eq("http://www.example.org/friends")
     end
 
     it 'should handle the nested attributes' do
-      @collection.items.first.href.should eq("http://www.example.org/m.rowe")
-      @collection.items.first.data.count.should eq(1)
+      expect(@collection.items.first.href).to eq("http://www.example.org/m.rowe")
+      expect(@collection.items.first.data.count).to eq(1)
     end
 
     it 'should be able to be reserialized' do
-      @collection.to_json.class.should eq(String)
+      expect(@collection.to_json.class).to eq(String)
     end
 
     it 'should have the correct link' do
-      @collection.links.first.href.should eq("http://www.example.org/friends.rss")
+      expect(@collection.links.first.href).to eq("http://www.example.org/friends.rss")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 EXAMPLE_HOST = "http://localhost"
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 end


### PR DESCRIPTION
Changed all uses of deprecated `.should` with `expect().to`. Alse, removed deprecated configuration setting.
